### PR TITLE
Install 'Faker' instead of deprecated 'fake-factory'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='stdg',
       packages=['stdg'],
       install_requires=[
           'ShopifyAPI',
-          'fake-factory',
+          'Faker',
           'pandas'
       ],
       zip_safe=False)


### PR DESCRIPTION
Foreign requirement 'fake-factory' was deprecated in favor of 'Faker'. Update the list of requirements to reflect this change.

Fixes ImportError upon running stdg after installing.

    ImportError:` The ``fake-factory`` package is now called ``Faker``.